### PR TITLE
Theme redesign: warm indigo + amber palette

### DIFF
--- a/src/components/about/BuiltForPhia.tsx
+++ b/src/components/about/BuiltForPhia.tsx
@@ -1,8 +1,8 @@
 const TheOpportunity = () => (
   <section className="mb-16">
-    <div className="bg-zinc-50 rounded-2xl p-8 md:p-10 border border-zinc-100 max-w-3xl mx-auto">
-      <h2 className="font-sans text-2xl font-bold text-zinc-900 text-center mb-6">The Opportunity</h2>
-      <div className="space-y-4 text-zinc-600 leading-relaxed">
+    <div className="bg-[#EDEAFC]/50 rounded-2xl p-8 md:p-10 border border-[#5B4FD6]/10 max-w-3xl mx-auto">
+      <h2 className="font-sans text-2xl font-bold text-stone-900 text-center mb-6">The Opportunity</h2>
+      <div className="space-y-4 text-stone-600 leading-relaxed">
         <p>
           ListIQ is designed as the seller-side complement to the "Should I Buy This?" experience — expanding the resale intelligence ecosystem from purchase advisor to full closet lifecycle manager.
         </p>

--- a/src/components/about/HowItWorksDetail.tsx
+++ b/src/components/about/HowItWorksDetail.tsx
@@ -8,16 +8,16 @@ const steps = [
 
 const HowItWorksDetail = () => (
   <section className="mb-16">
-    <h2 className="font-sans text-2xl md:text-3xl font-bold text-zinc-900 text-center mb-10">How ListIQ Works</h2>
+    <h2 className="font-sans text-2xl md:text-3xl font-bold text-stone-900 text-center mb-10">How ListIQ Works</h2>
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
       {steps.map((step, i) => (
-        <div key={step.title} className="bg-white rounded-2xl border border-zinc-100 shadow-sm p-8 text-center">
-          <div className="w-12 h-12 rounded-full bg-zinc-100 flex items-center justify-center mx-auto mb-4">
-            <step.icon size={22} className="text-zinc-600" />
+        <div key={step.title} className="bg-white rounded-2xl border border-stone-200 shadow-sm p-8 text-center">
+          <div className="w-12 h-12 rounded-full bg-[#EDEAFC] flex items-center justify-center mx-auto mb-4">
+            <step.icon size={22} className="text-[#5B4FD6]" />
           </div>
-          <p className="text-xs font-medium text-zinc-400 uppercase tracking-wider mb-1">Step {i + 1}</p>
-          <h3 className="font-sans text-lg font-bold text-zinc-900 mb-2">{step.title}</h3>
-          <p className="text-sm text-zinc-500 leading-relaxed">{step.description}</p>
+          <p className="text-xs font-medium text-[#5B4FD6] uppercase tracking-wider mb-1">Step {i + 1}</p>
+          <h3 className="font-sans text-lg font-bold text-stone-900 mb-2">{step.title}</h3>
+          <p className="text-sm text-stone-500 leading-relaxed">{step.description}</p>
         </div>
       ))}
     </div>

--- a/src/components/about/TeamSection.tsx
+++ b/src/components/about/TeamSection.tsx
@@ -6,19 +6,19 @@ const team = [
 
 const TeamSection = () => (
   <section className="mb-16">
-    <h2 className="font-sans text-2xl font-bold text-zinc-900 text-center mb-10">The Team</h2>
+    <h2 className="font-sans text-2xl font-bold text-stone-900 text-center mb-10">The Team</h2>
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-3xl mx-auto">
       {team.map((member) => (
         <div key={member.name} className="text-center">
-          <div className="w-20 h-20 rounded-full bg-zinc-100 mx-auto mb-4 flex items-center justify-center">
-            <span className="text-2xl font-bold text-zinc-700">{member.name[0]}</span>
+          <div className="w-20 h-20 rounded-full bg-[#EDEAFC] mx-auto mb-4 flex items-center justify-center">
+            <span className="text-2xl font-bold text-[#5B4FD6]">{member.name[0]}</span>
           </div>
-          <p className="font-sans text-lg font-bold text-zinc-900">{member.name}</p>
-          <p className="text-sm text-zinc-500">{member.role}</p>
+          <p className="font-sans text-lg font-bold text-stone-900">{member.name}</p>
+          <p className="text-sm text-stone-500">{member.role}</p>
         </div>
       ))}
     </div>
-    <p className="text-xs text-zinc-400 text-center mt-6">
+    <p className="text-xs text-stone-400 text-center mt-6">
       UC Berkeley · Data 198: Fashion × Data Science · Spring 2026
     </p>
   </section>

--- a/src/components/analyze/ExampleItems.tsx
+++ b/src/components/analyze/ExampleItems.tsx
@@ -7,13 +7,13 @@ const emojis = ["🧥", "👟", "👜", "👕"];
 
 const ExampleItems = ({ labels, onSelect }: ExampleItemsProps) => (
   <div className="mt-6">
-    <p className="text-sm text-zinc-400 font-medium mb-3 text-center">Try an Example</p>
+    <p className="text-sm text-stone-400 font-medium mb-3 text-center">Try an Example</p>
     <div className="flex flex-wrap justify-center gap-3">
       {labels.map((label, i) => (
         <button
           key={label}
           onClick={() => onSelect(i)}
-          className="flex items-center gap-2 px-5 py-2.5 rounded-full border border-zinc-200 text-sm font-medium text-zinc-600 hover:border-zinc-400 hover:text-zinc-900 transition-all duration-200"
+          className="flex items-center gap-2 px-5 py-2.5 rounded-full border border-stone-200 text-sm font-medium text-stone-600 hover:border-[#5B4FD6] hover:text-[#5B4FD6] hover:bg-[#EDEAFC]/40 transition-all duration-200"
         >
           <span className="text-lg">{emojis[i]}</span>
           {label}

--- a/src/components/analyze/PhotoUpload.tsx
+++ b/src/components/analyze/PhotoUpload.tsx
@@ -22,12 +22,12 @@ const PhotoUpload = ({ onFileSelected }: PhotoUploadProps) => {
       onDrop={handleDrop}
       className="block cursor-pointer"
     >
-      <div className="border-2 border-dashed border-zinc-200 rounded-2xl p-12 md:p-16 text-center hover:border-zinc-400 transition-all duration-200">
-        <div className="w-12 h-12 rounded-full bg-zinc-100 flex items-center justify-center mx-auto">
-          <Camera size={24} className="text-zinc-600" />
+      <div className="border-2 border-dashed border-stone-300 rounded-2xl p-12 md:p-16 text-center hover:border-[#5B4FD6] hover:bg-[#EDEAFC]/30 transition-all duration-200">
+        <div className="w-12 h-12 rounded-full bg-[#EDEAFC] flex items-center justify-center mx-auto">
+          <Camera size={24} className="text-[#5B4FD6]" />
         </div>
-        <p className="text-zinc-700 font-medium text-lg mt-4">Drop your item photo here or click to upload</p>
-        <p className="text-zinc-400 text-sm mt-2 flex items-center justify-center gap-1">
+        <p className="text-stone-700 font-medium text-lg mt-4">Drop your item photo here or click to upload</p>
+        <p className="text-stone-400 text-sm mt-2 flex items-center justify-center gap-1">
           <Upload size={14} /> JPG, PNG up to 10MB
         </p>
       </div>

--- a/src/components/intelligence/ChartPlaceholder.tsx
+++ b/src/components/intelligence/ChartPlaceholder.tsx
@@ -6,10 +6,10 @@ interface ChartPlaceholderProps {
 }
 
 const ChartPlaceholder = ({ title, icon: Icon }: ChartPlaceholderProps) => (
-  <div className="bg-white rounded-2xl border border-zinc-100 p-8 flex flex-col items-center justify-center min-h-[300px]">
-    <Icon size={64} className="text-zinc-200" />
-    <h3 className="font-sans text-xl font-bold text-zinc-900 mt-4 text-center">{title}</h3>
-    <p className="text-sm text-zinc-400 mt-2">Coming soon</p>
+  <div className="bg-white rounded-2xl border border-stone-200 p-8 flex flex-col items-center justify-center min-h-[300px]">
+    <Icon size={64} className="text-[#5B4FD6]/20" />
+    <h3 className="font-sans text-xl font-bold text-stone-900 mt-4 text-center">{title}</h3>
+    <p className="text-sm text-stone-400 mt-2">Coming soon</p>
   </div>
 );
 

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -3,15 +3,15 @@ import { ChevronRight } from "lucide-react";
 
 const HeroSection = () => (
   <section className="py-24 md:py-32 text-center px-6 md:px-12">
-    <h1 className="font-serif text-5xl md:text-7xl font-bold text-zinc-900 leading-tight tracking-tight max-w-4xl mx-auto">
+    <h1 className="font-serif text-5xl md:text-7xl font-bold text-stone-900 leading-tight tracking-tight max-w-4xl mx-auto">
       Should I Sell This?
     </h1>
-    <p className="mt-6 text-lg text-zinc-400 max-w-xl mx-auto leading-relaxed">
+    <p className="mt-6 text-lg text-stone-500 max-w-xl mx-auto leading-relaxed">
       Upload a photo of your clothing item. Get a cross-platform resale intelligence report in seconds.
     </p>
     <Link
       to="/analyze"
-      className="mt-10 inline-flex items-center gap-2 bg-zinc-900 hover:bg-zinc-800 text-white font-medium px-8 py-4 rounded-full text-base transition-all duration-200"
+      className="mt-10 inline-flex items-center gap-2 bg-[#5B4FD6] hover:bg-[#4A3FC2] text-white font-medium px-8 py-4 rounded-full text-base transition-all duration-200 shadow-sm hover:shadow-md"
     >
       Analyze My Item
       <ChevronRight size={18} />

--- a/src/components/landing/HowItWorks.tsx
+++ b/src/components/landing/HowItWorks.tsx
@@ -8,19 +8,19 @@ const steps = [
 
 const HowItWorks = () => (
   <section className="max-w-[1200px] mx-auto px-6 md:px-12 pb-20">
-    <h2 className="font-sans text-2xl font-bold text-center mb-12 text-zinc-900">How It Works</h2>
+    <h2 className="font-sans text-2xl font-bold text-center mb-12 text-stone-900">How It Works</h2>
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
       {steps.map((step, i) => (
         <div
           key={step.title}
-          className="bg-white rounded-2xl border border-zinc-100 shadow-sm p-8 text-center hover:shadow-md hover:-translate-y-1 transition-all duration-300"
+          className="bg-white rounded-2xl border border-stone-200 shadow-sm p-8 text-center hover:shadow-md hover:-translate-y-1 transition-all duration-300"
         >
-          <div className="w-14 h-14 rounded-full bg-zinc-100 flex items-center justify-center mx-auto mb-4">
-            <step.icon size={22} className="text-zinc-600" />
+          <div className="w-14 h-14 rounded-full bg-[#EDEAFC] flex items-center justify-center mx-auto mb-4">
+            <step.icon size={22} className="text-[#5B4FD6]" />
           </div>
-          <p className="text-xs font-medium text-zinc-400 uppercase tracking-wider mb-2">Step {i + 1}</p>
-          <h3 className="font-sans text-lg font-bold text-zinc-900 mb-3">{step.title}</h3>
-          <p className="text-zinc-500 text-sm leading-relaxed">{step.description}</p>
+          <p className="text-xs font-medium text-[#5B4FD6] uppercase tracking-wider mb-2">Step {i + 1}</p>
+          <h3 className="font-sans text-lg font-bold text-stone-900 mb-3">{step.title}</h3>
+          <p className="text-stone-500 text-sm leading-relaxed">{step.description}</p>
         </div>
       ))}
     </div>

--- a/src/components/landing/StatsBar.tsx
+++ b/src/components/landing/StatsBar.tsx
@@ -6,11 +6,11 @@ const stats = [
 
 const StatsBar = () => (
   <section className="max-w-[1200px] mx-auto px-6 md:px-12 py-16">
-    <div className="grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 md:divide-x divide-zinc-200">
+    <div className="grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 md:divide-x divide-stone-200">
       {stats.map((stat) => (
         <div key={stat.label} className="text-center py-6 md:py-0 px-4">
-          <p className="font-serif text-4xl md:text-5xl font-bold text-zinc-900">{stat.value}</p>
-          <p className="mt-1 text-sm text-zinc-400 font-medium">{stat.label}</p>
+          <p className="font-serif text-4xl md:text-5xl font-bold text-stone-900">{stat.value}</p>
+          <p className="mt-1 text-sm text-stone-400 font-medium">{stat.label}</p>
         </div>
       ))}
     </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,8 +1,11 @@
 const Footer = () => (
-  <footer className="border-t border-zinc-100 py-8 mt-20">
+  <footer className="border-t border-stone-200 py-8 mt-20">
     <div className="max-w-[1200px] mx-auto px-6 md:px-12 text-center">
-      <p className="text-sm text-zinc-400">
-        Built by <span className="font-bold text-zinc-900">ListIQ</span> · UC Berkeley Data 198 · Spring 2026
+      <p className="text-sm text-stone-400">
+        Built by{" "}
+        <span className="font-bold text-stone-900">List</span>
+        <span className="font-bold text-[#5B4FD6]">IQ</span>
+        {" "}· UC Berkeley Data 198 · Spring 2026
       </p>
     </div>
   </footer>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -13,11 +13,11 @@ const Navbar = () => {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   return (
-    <nav className="sticky top-0 z-50 bg-white border-b border-zinc-100">
+    <nav className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-stone-200">
       <div className="max-w-[1200px] mx-auto flex items-center justify-between px-6 md:px-12 h-16">
         <Link to="/" className="text-xl tracking-tight">
-          <span className="font-serif font-bold text-zinc-900">List</span>
-          <span className="font-sans font-light text-zinc-400">IQ</span>
+          <span className="font-serif font-bold text-stone-900">List</span>
+          <span className="font-sans font-bold text-[#5B4FD6]">IQ</span>
         </Link>
 
         {/* Desktop */}
@@ -28,8 +28,8 @@ const Navbar = () => {
               to={link.to}
               className={`text-sm transition-colors ${
                 location.pathname === link.to
-                  ? "text-zinc-900 font-medium border-b-2 border-zinc-900 pb-0.5"
-                  : "text-zinc-500 hover:text-zinc-900"
+                  ? "text-[#5B4FD6] font-medium border-b-2 border-[#5B4FD6] pb-0.5"
+                  : "text-stone-500 hover:text-stone-900"
               }`}
             >
               {link.label}
@@ -39,7 +39,7 @@ const Navbar = () => {
 
         {/* Mobile toggle */}
         <button
-          className="md:hidden text-zinc-900"
+          className="md:hidden text-stone-900"
           onClick={() => setMobileOpen(!mobileOpen)}
         >
           {mobileOpen ? <X size={24} /> : <Menu size={24} />}
@@ -48,7 +48,7 @@ const Navbar = () => {
 
       {/* Mobile menu */}
       {mobileOpen && (
-        <div className="md:hidden border-t border-zinc-100 bg-white px-6 py-4 space-y-3">
+        <div className="md:hidden border-t border-stone-200 bg-white px-6 py-4 space-y-3">
           {navLinks.map((link) => (
             <Link
               key={link.to}
@@ -56,8 +56,8 @@ const Navbar = () => {
               onClick={() => setMobileOpen(false)}
               className={`block text-sm ${
                 location.pathname === link.to
-                  ? "text-zinc-900 font-medium"
-                  : "text-zinc-500"
+                  ? "text-[#5B4FD6] font-medium"
+                  : "text-stone-500"
               }`}
             >
               {link.label}

--- a/src/components/results/ItemCard.tsx
+++ b/src/components/results/ItemCard.tsx
@@ -6,7 +6,7 @@ interface ItemCardProps {
 }
 
 const ItemCard = ({ item }: ItemCardProps) => (
-  <div className="bg-white rounded-2xl border border-zinc-100 shadow-sm p-6 md:p-8 flex flex-col md:flex-row gap-6 animate-fade-in">
+  <div className="bg-white rounded-2xl border border-stone-200 shadow-sm p-6 md:p-8 flex flex-col md:flex-row gap-6 animate-fade-in">
     {item.image_url ? (
       <img
         src={item.image_url}
@@ -14,13 +14,13 @@ const ItemCard = ({ item }: ItemCardProps) => (
         className="w-full md:w-40 h-40 object-cover rounded-xl"
       />
     ) : (
-      <div className="w-full md:w-40 h-40 rounded-xl bg-zinc-100 flex items-center justify-center">
-        <Camera size={32} className="text-zinc-300" />
+      <div className="w-full md:w-40 h-40 rounded-xl bg-stone-100 flex items-center justify-center">
+        <Camera size={32} className="text-stone-300" />
       </div>
     )}
     <div className="flex-1">
-      <h3 className="font-sans text-xl md:text-2xl font-bold text-zinc-900">{item.brand} {item.category}</h3>
-      <p className="text-sm text-zinc-400 mt-1">Est. retail ${item.estimated_retail.toFixed(2)}</p>
+      <h3 className="font-sans text-xl md:text-2xl font-bold text-stone-900">{item.brand} {item.category}</h3>
+      <p className="text-sm text-stone-400 mt-1">Est. retail ${item.estimated_retail.toFixed(2)}</p>
       <div className="mt-3 flex flex-wrap gap-2">
         {[
           { label: "Size", value: item.size },
@@ -29,7 +29,7 @@ const ItemCard = ({ item }: ItemCardProps) => (
         ].map((attr) => (
           <span
             key={attr.label}
-            className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-zinc-100 text-zinc-700"
+            className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-[#EDEAFC] text-[#5B4FD6]"
           >
             {attr.label}: {attr.value}
           </span>

--- a/src/components/results/PlatformRanking.tsx
+++ b/src/components/results/PlatformRanking.tsx
@@ -18,9 +18,9 @@ const platformBorderColor: Record<string, string> = {
 };
 
 const platformBgTint: Record<string, string> = {
-  Depop: "bg-red-50/40",
-  Poshmark: "bg-purple-50/40",
-  eBay: "bg-blue-50/40",
+  Depop: "bg-red-50/50",
+  Poshmark: "bg-purple-50/50",
+  eBay: "bg-blue-50/50",
 };
 
 const PlatformRanking = ({ recommendations }: PlatformRankingProps) => {
@@ -28,10 +28,10 @@ const PlatformRanking = ({ recommendations }: PlatformRankingProps) => {
   const top = sorted[0];
 
   return (
-    <div className="bg-white rounded-2xl border border-zinc-100 shadow-sm p-6 md:p-8 animate-fade-in" style={{ animationDelay: "0.1s" }}>
+    <div className="bg-white rounded-2xl border border-stone-200 shadow-sm p-6 md:p-8 animate-fade-in" style={{ animationDelay: "0.1s" }}>
       <div className="flex items-center gap-2 mb-6">
-        <Trophy size={18} className="text-zinc-400" />
-        <h3 className="font-sans text-lg font-bold text-zinc-900">Platform Rankings</h3>
+        <Trophy size={18} className="text-[#E5A22D]" />
+        <h3 className="font-sans text-lg font-bold text-stone-900">Platform Rankings</h3>
       </div>
 
       {/* #1 platform — hero card */}
@@ -39,25 +39,25 @@ const PlatformRanking = ({ recommendations }: PlatformRankingProps) => {
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
             <span className={`w-3 h-3 rounded-full ${platformDotColor[top.platform]}`} />
-            <span className="font-sans text-xl font-bold text-zinc-900">{top.platform}</span>
-            <span className="bg-zinc-900 text-white text-xs font-bold px-3 py-1 rounded-full ml-2">Best Match</span>
+            <span className="font-sans text-xl font-bold text-stone-900">{top.platform}</span>
+            <span className="bg-[#5B4FD6] text-white text-xs font-bold px-3 py-1 rounded-full ml-2">Best Match</span>
           </div>
-          <span className="text-sm font-medium text-zinc-600 bg-zinc-100 px-3 py-1 rounded-full">
+          <span className="text-sm font-medium text-[#5B4FD6] bg-[#EDEAFC] px-3 py-1 rounded-full">
             {top.fit_score}/10
           </span>
         </div>
         <div className="grid grid-cols-3 gap-4 text-center">
           <div>
-            <p className="font-serif text-2xl font-bold text-zinc-900">${top.net_profit.balanced.toFixed(0)}</p>
-            <p className="text-xs text-zinc-500">net profit</p>
+            <p className="font-serif text-2xl font-bold text-stone-900">${top.net_profit.balanced.toFixed(0)}</p>
+            <p className="text-xs text-stone-500">net profit</p>
           </div>
           <div>
-            <p className="font-serif text-2xl font-bold text-zinc-900">{top.estimated_days_to_sale}d</p>
-            <p className="text-xs text-zinc-500">to sell</p>
+            <p className="font-serif text-2xl font-bold text-stone-900">{top.estimated_days_to_sale}d</p>
+            <p className="text-xs text-stone-500">to sell</p>
           </div>
           <div>
-            <p className="font-serif text-2xl font-bold text-zinc-900">${top.effective_hourly_rate.toFixed(0)}/hr</p>
-            <p className="text-xs text-zinc-500">effective rate</p>
+            <p className="font-serif text-2xl font-bold text-[#E5A22D]">${top.effective_hourly_rate.toFixed(0)}/hr</p>
+            <p className="text-xs text-stone-500">effective rate</p>
           </div>
         </div>
       </div>
@@ -65,17 +65,17 @@ const PlatformRanking = ({ recommendations }: PlatformRankingProps) => {
       {/* #2 and #3 */}
       <div className="grid grid-cols-2 gap-3">
         {sorted.slice(1).map((rec) => (
-          <div key={rec.platform} className="bg-zinc-50 rounded-xl p-4 text-center">
+          <div key={rec.platform} className="bg-[#F2F0EB] rounded-xl p-4 text-center">
             <div className="flex items-center justify-center gap-1.5 mb-2">
               <span className={`w-2 h-2 rounded-full ${platformDotColor[rec.platform]}`} />
-              <span className="text-sm font-medium text-zinc-700">{rec.platform}</span>
-              <span className="text-xs text-zinc-400 ml-1">{rec.fit_score}/10</span>
+              <span className="text-sm font-medium text-stone-700">{rec.platform}</span>
+              <span className="text-xs text-stone-400 ml-1">{rec.fit_score}/10</span>
             </div>
-            <p className="font-serif text-xl font-bold text-zinc-900">${rec.net_profit.balanced.toFixed(0)}</p>
-            <p className="text-xs text-zinc-500">net profit</p>
-            <div className="mt-2 pt-2 border-t border-zinc-200 flex justify-center gap-4">
-              <span className="text-xs text-zinc-500">{rec.estimated_days_to_sale}d</span>
-              <span className="text-xs font-medium text-zinc-700">${rec.effective_hourly_rate.toFixed(0)}/hr</span>
+            <p className="font-serif text-xl font-bold text-stone-900">${rec.net_profit.balanced.toFixed(0)}</p>
+            <p className="text-xs text-stone-500">net profit</p>
+            <div className="mt-2 pt-2 border-t border-stone-300 flex justify-center gap-4">
+              <span className="text-xs text-stone-500">{rec.estimated_days_to_sale}d</span>
+              <span className="text-xs font-medium text-[#E5A22D]">${rec.effective_hourly_rate.toFixed(0)}/hr</span>
             </div>
           </div>
         ))}

--- a/src/components/results/PriceTiers.tsx
+++ b/src/components/results/PriceTiers.tsx
@@ -16,10 +16,10 @@ const tiers = [
 ];
 
 const PriceTiersComponent = ({ priceTiers, netProfit, platformFeePct, estimatedShipping, platform }: PriceTiersProps) => (
-  <div className="bg-white rounded-2xl border border-zinc-100 shadow-sm p-6 md:p-8 animate-fade-in" style={{ animationDelay: "0.2s" }}>
+  <div className="bg-white rounded-2xl border border-stone-200 shadow-sm p-6 md:p-8 animate-fade-in" style={{ animationDelay: "0.2s" }}>
     <div className="flex items-center gap-2 mb-6">
-      <Scale size={18} className="text-zinc-400" />
-      <h3 className="font-sans text-lg font-bold text-zinc-900">Price Tiers on {platform}</h3>
+      <Scale size={18} className="text-[#E5A22D]" />
+      <h3 className="font-sans text-lg font-bold text-stone-900">Price Tiers on {platform}</h3>
     </div>
 
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -31,20 +31,20 @@ const PriceTiersComponent = ({ priceTiers, netProfit, platformFeePct, estimatedS
           <div
             key={tier.key}
             className={`rounded-xl p-5 text-center relative ${
-              isMiddle ? "ring-2 ring-zinc-900 bg-zinc-50" : "border border-zinc-100 bg-white"
+              isMiddle ? "ring-2 ring-[#5B4FD6] bg-[#EDEAFC]/40" : "border border-stone-200 bg-white"
             }`}
           >
             {isMiddle && (
-              <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 bg-zinc-900 text-white text-xs font-bold px-2 py-0.5 rounded-full">
+              <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 bg-[#5B4FD6] text-white text-xs font-bold px-2 py-0.5 rounded-full">
                 Recommended
               </span>
             )}
-            <tier.icon size={18} className={`mx-auto mb-2 ${isMiddle ? "text-zinc-900" : "text-zinc-400"}`} />
-            <p className="text-xs font-medium text-zinc-500 mb-1">{tier.label}</p>
-            <p className="text-sm text-zinc-400 line-through">${salePrice}</p>
-            <p className="font-serif text-3xl md:text-4xl font-bold text-zinc-900 mt-1">${net.toFixed(2)}</p>
-            <p className="text-sm font-medium text-zinc-600 mt-1">in your pocket</p>
-            <p className="text-xs text-zinc-400 mt-2">
+            <tier.icon size={18} className={`mx-auto mb-2 ${isMiddle ? "text-[#5B4FD6]" : "text-stone-400"}`} />
+            <p className="text-xs font-medium text-stone-500 mb-1">{tier.label}</p>
+            <p className="text-sm text-stone-400 line-through">${salePrice}</p>
+            <p className="font-serif text-3xl md:text-4xl font-bold text-stone-900 mt-1">${net.toFixed(2)}</p>
+            <p className="text-sm font-medium text-stone-600 mt-1">in your pocket</p>
+            <p className="text-xs text-stone-400 mt-2">
               after {Math.round(platformFeePct * 100)}% fee + ${estimatedShipping.toFixed(2)} shipping
             </p>
           </div>

--- a/src/components/results/SellEstimate.tsx
+++ b/src/components/results/SellEstimate.tsx
@@ -12,22 +12,22 @@ const SellEstimate = ({ estimatedDays, sellProbability, platform }: SellEstimate
   const barColor = pct >= 70 ? "bg-emerald-500" : pct >= 50 ? "bg-amber-500" : "bg-red-500";
 
   return (
-    <div className="bg-white rounded-2xl border border-zinc-100 shadow-sm p-6 md:p-8 animate-fade-in" style={{ animationDelay: "0.3s" }}>
+    <div className="bg-white rounded-2xl border border-stone-200 shadow-sm p-6 md:p-8 animate-fade-in" style={{ animationDelay: "0.3s" }}>
       <div className="flex items-center gap-2 mb-6">
-        <Clock size={18} className="text-zinc-400" />
-        <h3 className="font-sans text-lg font-bold text-zinc-900">Sell Estimate on {platform}</h3>
+        <Clock size={18} className="text-[#5B4FD6]" />
+        <h3 className="font-sans text-lg font-bold text-stone-900">Sell Estimate on {platform}</h3>
       </div>
 
       <div className="grid grid-cols-2 gap-6">
         <div>
-          <p className="text-sm text-zinc-500 mb-1">Estimated Days to Sale</p>
-          <p className="font-serif text-5xl font-bold text-zinc-900">{estimatedDays}</p>
-          <p className="text-sm text-zinc-500 mt-1">days</p>
+          <p className="text-sm text-stone-500 mb-1">Estimated Days to Sale</p>
+          <p className="font-serif text-5xl font-bold text-stone-900">{estimatedDays}</p>
+          <p className="text-sm text-stone-500 mt-1">days</p>
         </div>
         <div>
-          <p className="text-sm text-zinc-500 mb-1">30-Day Sell Probability</p>
+          <p className="text-sm text-stone-500 mb-1">30-Day Sell Probability</p>
           <p className={`font-serif text-5xl font-bold ${colorClass}`}>{pct}%</p>
-          <div className="mt-2 w-full h-2 bg-zinc-100 rounded-full overflow-hidden">
+          <div className="mt-2 w-full h-2 bg-stone-100 rounded-full overflow-hidden">
             <div
               className={`h-full rounded-full transition-all duration-700 ${barColor}`}
               style={{ width: `${pct}%` }}

--- a/src/components/results/WhyThisPlatform.tsx
+++ b/src/components/results/WhyThisPlatform.tsx
@@ -25,14 +25,14 @@ const platformIconColor: Record<string, string> = {
 
 const WhyThisPlatform = ({ platform, reasoning }: WhyThisPlatformProps) => (
   <div
-    className={`rounded-2xl border-l-4 ${platformBorderColor[platform] || "border-l-gray-300"} ${platformBgColor[platform] || "bg-gray-50"} shadow-sm p-6 md:p-8 animate-fade-in`}
+    className={`rounded-2xl border-l-4 ${platformBorderColor[platform] || "border-l-stone-300"} ${platformBgColor[platform] || "bg-stone-50"} shadow-sm p-6 md:p-8 animate-fade-in`}
     style={{ animationDelay: "0.4s" }}
   >
     <div className="flex items-center gap-2 mb-3">
-      <Lightbulb size={18} className={platformIconColor[platform] || "text-gray-600"} />
-      <h3 className="font-serif text-xl font-bold text-gray-900">Why {platform}?</h3>
+      <Lightbulb size={18} className={platformIconColor[platform] || "text-stone-600"} />
+      <h3 className="font-sans text-xl font-bold text-stone-900">Why {platform}?</h3>
     </div>
-    <p className="text-gray-600 leading-relaxed text-base">{reasoning}</p>
+    <p className="text-stone-600 leading-relaxed text-base">{reasoning}</p>
   </div>
 );
 

--- a/src/components/results/WorthItVerdict.tsx
+++ b/src/components/results/WorthItVerdict.tsx
@@ -47,20 +47,20 @@ const WorthItVerdictComponent = ({ worthIt }: WorthItVerdictProps) => {
           <h2 className={`font-serif text-2xl md:text-3xl font-bold ${config.headlineColor} mb-2`}>
             {config.headline}
           </h2>
-          <p className="text-base text-zinc-600 leading-relaxed mb-4">
+          <p className="text-base text-stone-600 leading-relaxed mb-4">
             {worthIt.explanation}
           </p>
           <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2">
-            <p className="text-lg font-medium text-zinc-900">
+            <p className="text-lg font-medium text-stone-900">
               Estimated{" "}
               <span className={`font-serif text-3xl font-bold ${config.profitColor}`}>
                 ${worthIt.best_net_profit.toFixed(2)}
               </span>{" "}
               net on {worthIt.best_platform}
             </p>
-            <p className="text-lg font-semibold text-zinc-700">
+            <p className="text-lg font-semibold text-stone-700">
               ${worthIt.effective_hourly_rate.toFixed(2)}/hr
-              <span className="text-sm font-normal text-zinc-400 ml-1">effective rate</span>
+              <span className="text-sm font-normal text-stone-400 ml-1">effective rate</span>
             </p>
           </div>
           {isFalse && (

--- a/src/index.css
+++ b/src/index.css
@@ -6,57 +6,58 @@
 
 @layer base {
   :root {
-    --background: 0 0% 98%;
-    --foreground: 240 6% 10%;
+    --background: 40 20% 97%;
+    --foreground: 20 10% 10%;
 
     --card: 0 0% 100%;
-    --card-foreground: 240 6% 10%;
+    --card-foreground: 20 10% 10%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 240 6% 10%;
+    --popover-foreground: 20 10% 10%;
 
-    --primary: 240 6% 10%;
+    --primary: 248 62% 57%;
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 240 5% 96%;
-    --secondary-foreground: 240 6% 10%;
+    --secondary: 250 60% 96%;
+    --secondary-foreground: 248 62% 57%;
 
-    --muted: 240 4% 46%;
-    --muted-foreground: 240 4% 46%;
+    --muted: 25 6% 46%;
+    --muted-foreground: 25 6% 46%;
 
-    --accent: 240 5% 96%;
-    --accent-foreground: 240 6% 10%;
+    --accent: 250 60% 96%;
+    --accent-foreground: 248 62% 57%;
 
     --destructive: 0 72% 51%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 240 6% 90%;
-    --input: 240 6% 90%;
-    --ring: 240 6% 10%;
+    --border: 20 6% 90%;
+    --input: 20 6% 90%;
+    --ring: 248 62% 57%;
 
     --radius: 0.75rem;
 
-    /* Backgrounds */
-    --color-bg: #FAFAFA;
+    /* Backgrounds — warm stone base */
+    --color-bg: #F8F7F4;
     --color-bg-card: #FFFFFF;
-    --color-bg-subtle: #F5F5F4;
+    --color-bg-subtle: #F2F0EB;
     --color-bg-elevated: #FFFFFF;
 
-    /* Text */
-    --color-text-primary: #18181B;
-    --color-text-secondary: #71717A;
-    --color-text-muted: #A1A1AA;
+    /* Text — warm, not cold */
+    --color-text-primary: #1C1917;
+    --color-text-secondary: #78716C;
+    --color-text-muted: #A8A29E;
 
-    /* ListIQ brand accent */
-    --color-accent: #18181B;
-    --color-accent-soft: #F4F4F5;
+    /* Brand accent — warm indigo (intelligence, fashion heritage) */
+    --color-accent: #5B4FD6;
+    --color-accent-hover: #4A3FC2;
+    --color-accent-soft: #EDEAFC;
 
-    /* Action color */
-    --color-action: #2563EB;
-    --color-action-hover: #1D4ED8;
-    --color-action-soft: #EFF6FF;
+    /* Action / value — warm amber (opportunity, money) */
+    --color-action: #E5A22D;
+    --color-action-hover: #D4911F;
+    --color-action-soft: #FDF6E8;
 
-    /* Verdict states */
+    /* Verdict states — emotional color pops */
     --color-verdict-green: #059669;
     --color-verdict-green-bg: #ECFDF5;
     --color-verdict-amber: #D97706;
@@ -64,13 +65,10 @@
     --color-verdict-red: #DC2626;
     --color-verdict-red-bg: #FEF2F2;
 
-    /* Platform brand colors */
+    /* Platform brand colors — sacred, never change */
     --color-depop: #FF2300;
     --color-poshmark: #7B2D8E;
     --color-ebay: #0064D2;
-
-    /* Pricing */
-    --color-money: #18181B;
 
     --sidebar-background: 0 0% 98%;
     --sidebar-foreground: 240 5.3% 26.1%;
@@ -78,8 +76,8 @@
     --sidebar-primary-foreground: 0 0% 98%;
     --sidebar-accent: 240 4.8% 95.9%;
     --sidebar-accent-foreground: 240 5.9% 10%;
-    --sidebar-border: 240 6% 90%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-border: 20 6% 90%;
+    --sidebar-ring: 248 62% 57%;
   }
 }
 
@@ -90,8 +88,8 @@
 
   body {
     font-family: 'DM Sans', sans-serif;
-    background-color: #FAFAFA;
-    color: #18181B;
+    background-color: #F8F7F4;
+    color: #1C1917;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -4,16 +4,16 @@ import TeamSection from "@/components/about/TeamSection";
 import Footer from "@/components/layout/Footer";
 
 const About = () => (
-  <div className="min-h-screen bg-[#FAFAFA] pt-24 pb-12">
+  <div className="min-h-screen bg-[#F8F7F4] pt-24 pb-12">
     <div className="max-w-[1200px] mx-auto px-6 md:px-12">
-      <h1 className="font-sans text-4xl md:text-5xl font-bold text-zinc-900 text-center mb-12">About ListIQ</h1>
+      <h1 className="font-sans text-4xl md:text-5xl font-bold text-stone-900 text-center mb-12">About ListIQ</h1>
 
       <HowItWorksDetail />
 
       <section className="mb-16 max-w-3xl mx-auto">
-        <h2 className="font-sans text-2xl font-bold text-zinc-900 text-center mb-6">Our Data</h2>
-        <div className="bg-white rounded-2xl border border-zinc-100 shadow-sm p-8 md:p-10">
-          <div className="space-y-4 text-zinc-600 leading-relaxed text-base">
+        <h2 className="font-sans text-2xl font-bold text-stone-900 text-center mb-6">Our Data</h2>
+        <div className="bg-white rounded-2xl border border-stone-200 shadow-sm p-8 md:p-10">
+          <div className="space-y-4 text-stone-600 leading-relaxed text-base">
             <p>
               ListIQ analyzes over 10,000 real sold listings scraped from Poshmark, eBay, and Depop.
               Our ML models identify patterns in pricing, sell-through rates, and platform-item fit

--- a/src/pages/Analyze.tsx
+++ b/src/pages/Analyze.tsx
@@ -72,12 +72,12 @@ const Analyze = () => {
   const top = result?.recommendations.find((r) => r.rank === 1);
 
   return (
-    <div className="min-h-screen bg-[#FAFAFA] pt-24 pb-12">
+    <div className="min-h-screen bg-[#F8F7F4] pt-24 pb-12">
       <div className="max-w-[1200px] mx-auto px-6 md:px-12">
         {step === "upload" && (
           <>
-            <h1 className="font-sans text-4xl md:text-5xl font-bold text-zinc-900 text-center mb-3">Analyze Your Item</h1>
-            <p className="text-center text-zinc-400 text-lg mb-10">Upload a photo or try an example to get started.</p>
+            <h1 className="font-sans text-4xl md:text-5xl font-bold text-stone-900 text-center mb-3">Analyze Your Item</h1>
+            <p className="text-center text-stone-500 text-lg mb-10">Upload a photo or try an example to get started.</p>
             <div className="max-w-2xl mx-auto">
               <PhotoUpload onFileSelected={handleFileSelected} />
               <ExampleItems labels={exampleLabels} onSelect={handleExampleSelect} />
@@ -118,7 +118,7 @@ const Analyze = () => {
             <div className="text-center pt-8">
               <button
                 onClick={resetFlow}
-                className="inline-flex items-center gap-2 bg-zinc-900 hover:bg-zinc-800 text-white font-medium px-6 py-3 rounded-full transition-all duration-200"
+                className="inline-flex items-center gap-2 bg-[#5B4FD6] hover:bg-[#4A3FC2] text-white font-medium px-6 py-3 rounded-full transition-all duration-200"
               >
                 ← Analyze Another Item
               </button>

--- a/src/pages/Intelligence.tsx
+++ b/src/pages/Intelligence.tsx
@@ -9,10 +9,10 @@ const charts = [
 ];
 
 const Intelligence = () => (
-  <div className="min-h-screen bg-[#FAFAFA] pt-24 pb-12">
+  <div className="min-h-screen bg-[#F8F7F4] pt-24 pb-12">
     <div className="max-w-[1200px] mx-auto px-6 md:px-12">
-      <h1 className="font-sans text-4xl md:text-5xl font-bold text-zinc-900 text-center mb-3">Platform Intelligence Dashboard</h1>
-      <p className="text-center text-zinc-400 text-lg mb-12 max-w-2xl mx-auto">
+      <h1 className="font-sans text-4xl md:text-5xl font-bold text-stone-900 text-center mb-3">Platform Intelligence Dashboard</h1>
+      <p className="text-center text-stone-500 text-lg mb-12 max-w-2xl mx-auto">
         Insights from 10,000+ real sold listings across Poshmark, eBay, and Depop
       </p>
 
@@ -22,8 +22,8 @@ const Intelligence = () => (
         ))}
       </div>
 
-      <div className="bg-white rounded-2xl border border-zinc-100 shadow-sm p-8">
-        <h3 className="font-sans text-lg font-bold text-zinc-900 mb-4">Data Summary</h3>
+      <div className="bg-white rounded-2xl border border-stone-200 shadow-sm p-8">
+        <h3 className="font-sans text-lg font-bold text-stone-900 mb-4">Data Summary</h3>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
           {[
             { label: "Total Listings", value: "10,247" },
@@ -32,8 +32,8 @@ const Intelligence = () => (
             { label: "Platforms", value: "3" },
           ].map((stat) => (
             <div key={stat.label}>
-              <p className="text-sm text-zinc-500">{stat.label}</p>
-              <p className="font-serif text-3xl font-bold text-zinc-900 mt-1">{stat.value}</p>
+              <p className="text-sm text-stone-500">{stat.label}</p>
+              <p className="font-serif text-3xl font-bold text-stone-900 mt-1">{stat.value}</p>
             </div>
           ))}
         </div>

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -4,7 +4,7 @@ import HowItWorks from "@/components/landing/HowItWorks";
 import Footer from "@/components/layout/Footer";
 
 const Landing = () => (
-  <div className="min-h-screen bg-[#FAFAFA]">
+  <div className="min-h-screen bg-[#F8F7F4]">
     <HeroSection />
     <StatsBar />
     <HowItWorks />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -51,14 +51,15 @@ export default {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
-        brand: {
-          DEFAULT: '#18181B',
-          soft: '#F4F4F5',
+        indigo: {
+          DEFAULT: '#5B4FD6',
+          hover: '#4A3FC2',
+          soft: '#EDEAFC',
         },
-        action: {
-          DEFAULT: '#2563EB',
-          hover: '#1D4ED8',
-          soft: '#EFF6FF',
+        amber: {
+          DEFAULT: '#E5A22D',
+          hover: '#D4911F',
+          soft: '#FDF6E8',
         },
         depop: '#FF2300',
         poshmark: '#7B2D8E',


### PR DESCRIPTION
## Summary

Replaces the sterile zinc/gray theme with a warm, personality-driven palette that reflects ListIQ's identity as a **fashion intelligence** product.

### The design philosophy

The previous theme was pure neutral — zinc/charcoal/white. It looked professional but had zero personality. This redesign adds **purposeful color** while staying premium:

- **90% warm neutrals** (stone tones) — the UI stays calm
- **~5% indigo accent** (#5B4FD6) — signals interactivity and brand
- **~2% amber highlight** (#E5A22D) — signals value/money moments
- **~3% verdict + platform colors** — carries emotional data meaning

### Why indigo?

The word "indigo" literally comes from the textile dye trade — it's the color of denim, one of fashion's most iconic materials. It signals intelligence and depth (fitting for "IQ" in the name). And it sits in a unique color space that doesn't clash with Depop red, Poshmark purple, or eBay blue.

### Color mapping

| Element | Color | Hex | Reasoning |
|---------|-------|-----|-----------|
| Logo "IQ" | Warm indigo | `#5B4FD6` | Brand identity |
| CTA buttons | Warm indigo | `#5B4FD6` | Interactive elements |
| Icon circles | Indigo soft | `#EDEAFC` | Subtle brand presence |
| Active nav | Indigo | `#5B4FD6` | Navigation state |
| "Best Match" badge | Indigo | `#5B4FD6` | Recommendation highlight |
| Effective hourly rate | Warm amber | `#E5A22D` | Money/value signal |
| Trophy/price icons | Warm amber | `#E5A22D` | Value section markers |
| Fit score badge | Indigo soft | `#EDEAFC` | Data highlight |
| Page background | Warm stone | `#F8F7F4` | Editorial warmth |
| Card borders | Stone-200 | `#E7E5E4` | Warm, not clinical |
| Text primary | Stone-900 | `#1C1917` | Readable, warm black |
| Verdicts | Green/amber/red | unchanged | Emotional data color |
| Platform colors | Brand colors | unchanged | Sacred identity |

### Inspired by
- **Stripe**: indigo accent against clean neutrals
- **Notion**: warm off-white backgrounds (`#F7F6F3`)
- **Mercury**: calm sophistication, one accent color

## Test plan
- [ ] `npm run build` passes
- [ ] Landing: indigo CTA, warm background, indigo icon circles
- [ ] Analyze: indigo hover on upload zone and example buttons
- [ ] Results: verdicts pop (green/red) against warm background
- [ ] Amber hourly rate visible on platform ranking cards
- [ ] Indigo "Best Match" badge + "Recommended" price tier badge
- [ ] Platform colors untouched (Depop red, Poshmark purple, eBay blue)
- [ ] Navbar: "List" in serif black, "IQ" in indigo
- [ ] Mobile: all pages responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)