### PR TITLE
Integrate backend fixtures

### DIFF
--- a/public/fixtures/anthropologie-midi-dress.json
+++ b/public/fixtures/anthropologie-midi-dress.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "midi dress",
+    "brand": "Anthropologie",
+    "size": "M",
+    "condition": "Like New",
+    "color": "floral",
+    "estimated_retail": 148.0
+  },
+  "recommendations": [
+    {
+      "platform": "Poshmark",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 31,
+        "balanced": 45,
+        "max_revenue": 69
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 18.81,
+        "balanced": 30.01,
+        "max_revenue": 49.21
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 51.45,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 23,
+      "reasoning": "Midi Dresss nets $3 more than Depop on Poshmark after 20% fee"
+    },
+    {
+      "platform": "Depop",
+      "rank": 2,
+      "fit_score": 9.1,
+      "price_tiers": {
+        "fast_sale": 20,
+        "balanced": 37,
+        "max_revenue": 67
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 12.01,
+        "balanced": 27.31,
+        "max_revenue": 54.31
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 46.82,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 25,
+      "reasoning": "Depop has lower fees (10%) but estimated net profit is $3 less than Poshmark (listed-price proxy)"
+    },
+    {
+      "platform": "eBay",
+      "rank": 3,
+      "fit_score": 7.9,
+      "price_tiers": {
+        "fast_sale": 16,
+        "balanced": 34,
+        "max_revenue": 64
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 7.93,
+        "balanced": 23.59,
+        "max_revenue": 49.69
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 40.44,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 17,
+      "reasoning": "eBay offers faster sell-through (~17 days, 6 days quicker) but 13% fee leaves $6 less net profit"
+    }
+  ],
+  "worth_it": {
+    "verdict": true,
+    "best_net_profit": 30.01,
+    "best_platform": "Poshmark",
+    "effective_hourly_rate": 51.45,
+    "explanation": "Worth listing \u2014 estimated $19-49 net profit on Poshmark after fees and shipping"
+  },
+  "demo_item_id": "anthropologie-midi-dress",
+  "demo_narrative_purpose": "Poshmark wins \u2014 brand-audience fit"
+}

--- a/public/fixtures/coach-crossbody-bag.json
+++ b/public/fixtures/coach-crossbody-bag.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "crossbody bag",
+    "brand": "Coach",
+    "size": "OS",
+    "condition": "Like New",
+    "color": "tan",
+    "estimated_retail": 250.0
+  },
+  "recommendations": [
+    {
+      "platform": "eBay",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 32,
+        "balanced": 69,
+        "max_revenue": 158
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 21.85,
+        "balanced": 54.04,
+        "max_revenue": 131.47
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 92.64,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 28,
+      "reasoning": "Crossbody Bags nets $5 more than Poshmark and estimated 10 days faster on eBay after 13% fee"
+    },
+    {
+      "platform": "Poshmark",
+      "rank": 2,
+      "fit_score": 9.1,
+      "price_tiers": {
+        "fast_sale": 33,
+        "balanced": 69,
+        "max_revenue": 146
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 20.41,
+        "balanced": 49.21,
+        "max_revenue": 110.81
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 84.36,
+      "sell_probability_30d": 0.79,
+      "estimated_days_to_sale": 38,
+      "reasoning": "Poshmark is a viable alternative at $49 net profit in ~38 days (20% fee)"
+    },
+    {
+      "platform": "Depop",
+      "rank": 3,
+      "fit_score": 7.7,
+      "price_tiers": {
+        "fast_sale": 30,
+        "balanced": 53,
+        "max_revenue": 107
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 21.01,
+        "balanced": 41.71,
+        "max_revenue": 90.31
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 71.5,
+      "sell_probability_30d": 0.71,
+      "estimated_days_to_sale": 42,
+      "reasoning": "Depop has lower fees (10%) but estimated net profit is $12 less than eBay (limited training data \u2014 listed-price proxy)"
+    }
+  ],
+  "worth_it": {
+    "verdict": true,
+    "best_net_profit": 54.04,
+    "best_platform": "eBay",
+    "effective_hourly_rate": 92.64,
+    "explanation": "Worth listing \u2014 estimated $22-131 net profit on eBay after fees and shipping"
+  },
+  "demo_item_id": "coach-crossbody-bag",
+  "demo_narrative_purpose": "Premium accessory, strong eBay routing"
+}

--- a/public/fixtures/coach-handbag.json
+++ b/public/fixtures/coach-handbag.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "handbag",
+    "brand": "Coach",
+    "size": "OS",
+    "condition": "Good",
+    "color": "black",
+    "estimated_retail": 350.0
+  },
+  "recommendations": [
+    {
+      "platform": "Depop",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 48,
+        "balanced": 62,
+        "max_revenue": 132
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 37.21,
+        "balanced": 49.81,
+        "max_revenue": 112.81
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 85.39,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 24,
+      "reasoning": "Best overall value for handbags on Depop \u2014 $50 net profit in ~24 days (listed-price proxy)"
+    },
+    {
+      "platform": "eBay",
+      "rank": 2,
+      "fit_score": 9.8,
+      "price_tiers": {
+        "fast_sale": 27,
+        "balanced": 63,
+        "max_revenue": 145
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 17.5,
+        "balanced": 48.82,
+        "max_revenue": 120.16
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 83.69,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 16,
+      "reasoning": "eBay offers faster sell-through (~16 days, 8 days quicker) but 13% fee leaves $1 less net profit"
+    },
+    {
+      "platform": "Poshmark",
+      "rank": 3,
+      "fit_score": 9.4,
+      "price_tiers": {
+        "fast_sale": 28,
+        "balanced": 66,
+        "max_revenue": 155
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 16.41,
+        "balanced": 46.81,
+        "max_revenue": 118.01
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 80.25,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 22,
+      "reasoning": "Poshmark offers faster sell-through (~22 days, 2 days quicker) but 20% fee leaves $3 less net profit"
+    }
+  ],
+  "worth_it": {
+    "verdict": true,
+    "best_net_profit": 49.81,
+    "best_platform": "Depop",
+    "effective_hourly_rate": 85.39,
+    "explanation": "Worth listing \u2014 estimated $37-113 net profit on Depop after fees and shipping"
+  },
+  "demo_item_id": "coach-handbag",
+  "demo_narrative_purpose": "Surprising routing \u2014 Depop beats eBay/Poshmark for Coach (lowest fees win on mid-range)"
+}

--- a/public/fixtures/free-people-midi-dress.json
+++ b/public/fixtures/free-people-midi-dress.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "midi dress",
+    "brand": "Free People",
+    "size": "S",
+    "condition": "New",
+    "color": "white",
+    "estimated_retail": 128.0
+  },
+  "recommendations": [
+    {
+      "platform": "Poshmark",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 31,
+        "balanced": 44,
+        "max_revenue": 68
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 18.81,
+        "balanced": 29.21,
+        "max_revenue": 48.41
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 50.07,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 23,
+      "reasoning": "Midi Dresss nets $4 more than Depop on Poshmark after 20% fee"
+    },
+    {
+      "platform": "Depop",
+      "rank": 2,
+      "fit_score": 8.7,
+      "price_tiers": {
+        "fast_sale": 19,
+        "balanced": 35,
+        "max_revenue": 63
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 11.11,
+        "balanced": 25.51,
+        "max_revenue": 50.71
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 43.73,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 25,
+      "reasoning": "Depop has lower fees (10%) but estimated net profit is $4 less than Poshmark (listed-price proxy)"
+    },
+    {
+      "platform": "eBay",
+      "rank": 3,
+      "fit_score": 6.6,
+      "price_tiers": {
+        "fast_sale": 14,
+        "balanced": 29,
+        "max_revenue": 55
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 6.19,
+        "balanced": 19.24,
+        "max_revenue": 41.86
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 32.98,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 17,
+      "reasoning": "eBay offers faster sell-through (~17 days, 6 days quicker) but 13% fee leaves $10 less net profit"
+    }
+  ],
+  "worth_it": {
+    "verdict": true,
+    "best_net_profit": 29.21,
+    "best_platform": "Poshmark",
+    "effective_hourly_rate": 50.07,
+    "explanation": "Worth listing \u2014 estimated $19-48 net profit on Poshmark after fees and shipping"
+  },
+  "demo_item_id": "free-people-midi-dress",
+  "demo_narrative_purpose": "Poshmark wins again \u2014 brand-audience alignment"
+}

--- a/public/fixtures/handm-midi-dress.json
+++ b/public/fixtures/handm-midi-dress.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "midi dress",
+    "brand": "H&M",
+    "size": "S",
+    "condition": "Good",
+    "color": "black",
+    "estimated_retail": 24.99
+  },
+  "recommendations": [
+    {
+      "platform": "Poshmark",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 19,
+        "balanced": 27,
+        "max_revenue": 41
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 9.21,
+        "balanced": 15.61,
+        "max_revenue": 26.81
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 26.76,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 23,
+      "reasoning": "Midi Dresss nets $3 more than Depop on Poshmark after 20% fee"
+    },
+    {
+      "platform": "Depop",
+      "rank": 2,
+      "fit_score": 8.3,
+      "price_tiers": {
+        "fast_sale": 12,
+        "balanced": 21,
+        "max_revenue": 39
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 4.81,
+        "balanced": 12.91,
+        "max_revenue": 29.11
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 22.13,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 25,
+      "reasoning": "Depop has lower fees (10%) but estimated net profit is $3 less than Poshmark (listed-price proxy)"
+    },
+    {
+      "platform": "eBay",
+      "rank": 3,
+      "fit_score": 5.1,
+      "price_tiers": {
+        "fast_sale": 8,
+        "balanced": 16,
+        "max_revenue": 31
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 0.97,
+        "balanced": 7.93,
+        "max_revenue": 20.98
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 13.59,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 17,
+      "reasoning": "eBay offers faster sell-through (~17 days, 6 days quicker) but 13% fee leaves $8 less net profit"
+    }
+  ],
+  "worth_it": {
+    "verdict": true,
+    "best_net_profit": 15.61,
+    "best_platform": "Poshmark",
+    "effective_hourly_rate": 26.76,
+    "explanation": "Worth listing \u2014 estimated $9-27 net profit on Poshmark after fees and shipping"
+  },
+  "demo_item_id": "handm-midi-dress",
+  "demo_narrative_purpose": "Budget fast-fashion \u2014 barely clears worth-it threshold at $27/hr"
+}

--- a/public/fixtures/harley-davidson-vintage-t-shirt.json
+++ b/public/fixtures/harley-davidson-vintage-t-shirt.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "vintage t-shirt",
+    "brand": "Harley-Davidson",
+    "size": "L",
+    "condition": "Good",
+    "color": "black",
+    "estimated_retail": 45.0
+  },
+  "recommendations": [
+    {
+      "platform": "Depop",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 17,
+        "balanced": 31,
+        "max_revenue": 62
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 9.31,
+        "balanced": 21.91,
+        "max_revenue": 49.81
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 37.56,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 22,
+      "reasoning": "Best overall value for vintage t-shirts on Depop \u2014 $22 net profit in ~22 days (limited training data \u2014 listed-price proxy)"
+    },
+    {
+      "platform": "eBay",
+      "rank": 2,
+      "fit_score": 9.6,
+      "price_tiers": {
+        "fast_sale": 17,
+        "balanced": 31,
+        "max_revenue": 52
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 8.8,
+        "balanced": 20.98,
+        "max_revenue": 39.25
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 35.97,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 15,
+      "reasoning": "eBay offers faster sell-through (~15 days, 7 days quicker) but 13% fee leaves $1 less net profit"
+    },
+    {
+      "platform": "Poshmark",
+      "rank": 3,
+      "fit_score": 7.1,
+      "price_tiers": {
+        "fast_sale": 15,
+        "balanced": 27,
+        "max_revenue": 42
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 6.01,
+        "balanced": 15.61,
+        "max_revenue": 27.61
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 26.76,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 20,
+      "reasoning": "Poshmark offers faster sell-through (~20 days, 2 days quicker) but 20% fee leaves $6 less net profit"
+    }
+  ],
+  "worth_it": {
+    "verdict": true,
+    "best_net_profit": 21.91,
+    "best_platform": "Depop",
+    "effective_hourly_rate": 37.56,
+    "explanation": "Worth listing \u2014 estimated $9-50 net profit on Depop after fees and shipping"
+  },
+  "demo_item_id": "harley-davidson-vintage-t-shirt",
+  "demo_narrative_purpose": "2-way category, niche brand with collector appeal"
+}

--- a/public/fixtures/index.json
+++ b/public/fixtures/index.json
@@ -1,0 +1,130 @@
+[
+  {
+    "demo_item_id": "levis-denim-jacket",
+    "narrative_purpose": "Brand recognition opener \u2014 clear worth-it",
+    "category": "denim jacket",
+    "brand": "Levi's",
+    "best_platform": "eBay",
+    "verdict": true
+  },
+  {
+    "demo_item_id": "nike-sneakers",
+    "narrative_purpose": "Mass-market brand, high confidence routing",
+    "category": "sneakers",
+    "brand": "Nike",
+    "best_platform": "eBay",
+    "verdict": true
+  },
+  {
+    "demo_item_id": "jordan-sneakers",
+    "narrative_purpose": "Premium sneaker, highest sneaker ROI",
+    "category": "sneakers",
+    "brand": "Jordan",
+    "best_platform": "eBay",
+    "verdict": true
+  },
+  {
+    "demo_item_id": "louis-vuitton-handbag",
+    "narrative_purpose": "Luxury showcase \u2014 dramatic $/hr (note: luxury tier has high model uncertainty, MAE $339)",
+    "category": "handbag",
+    "brand": "Louis Vuitton",
+    "best_platform": "eBay",
+    "verdict": true
+  },
+  {
+    "demo_item_id": "coach-crossbody-bag",
+    "narrative_purpose": "Premium accessory, strong eBay routing",
+    "category": "crossbody bag",
+    "brand": "Coach",
+    "best_platform": "eBay",
+    "verdict": true
+  },
+  {
+    "demo_item_id": "anthropologie-midi-dress",
+    "narrative_purpose": "Poshmark wins \u2014 brand-audience fit",
+    "category": "midi dress",
+    "brand": "Anthropologie",
+    "best_platform": "Poshmark",
+    "verdict": true
+  },
+  {
+    "demo_item_id": "harley-davidson-vintage-t-shirt",
+    "narrative_purpose": "2-way category, niche brand with collector appeal",
+    "category": "vintage t-shirt",
+    "brand": "Harley-Davidson",
+    "best_platform": "Depop",
+    "verdict": true
+  },
+  {
+    "demo_item_id": "levis-leather-jacket",
+    "narrative_purpose": "High-value 2-way item, strong premium signal",
+    "category": "leather jacket",
+    "brand": "Levi's",
+    "best_platform": "eBay",
+    "verdict": true
+  },
+  {
+    "demo_item_id": "handm-midi-dress",
+    "narrative_purpose": "Budget fast-fashion \u2014 barely clears worth-it threshold at $27/hr",
+    "category": "midi dress",
+    "brand": "H&M",
+    "best_platform": "Poshmark",
+    "verdict": true
+  },
+  {
+    "demo_item_id": "unknown-blazer",
+    "narrative_purpose": "No brand signal, low confidence \u2014 marginal verdict",
+    "category": "blazer",
+    "brand": "Unknown",
+    "best_platform": "Poshmark",
+    "verdict": "marginal"
+  },
+  {
+    "demo_item_id": "unknown-midi-dress",
+    "narrative_purpose": "Cheapest item in demo \u2014 barely above threshold",
+    "category": "midi dress",
+    "brand": "Unknown",
+    "best_platform": "Poshmark",
+    "verdict": "marginal"
+  },
+  {
+    "demo_item_id": "zara-denim-jacket",
+    "narrative_purpose": "Known brand but low margin category \u2014 marginal zone",
+    "category": "denim jacket",
+    "brand": "Zara",
+    "best_platform": "Depop",
+    "verdict": "marginal"
+  },
+  {
+    "demo_item_id": "old-navy-denim-jacket",
+    "narrative_purpose": "THE 'don't sell' punchline \u2014 $13/hr, not worth your time",
+    "category": "denim jacket",
+    "brand": "Old Navy",
+    "best_platform": "Depop",
+    "verdict": false
+  },
+  {
+    "demo_item_id": "unknown-denim-jacket",
+    "narrative_purpose": "Marginal unknown brand \u2014 borderline at $19/hr, reinforces 'think twice'",
+    "category": "denim jacket",
+    "brand": "Unknown",
+    "best_platform": "Depop",
+    "verdict": "marginal"
+  },
+  {
+    "demo_item_id": "coach-handbag",
+    "narrative_purpose": "Surprising routing \u2014 Depop beats eBay/Poshmark for Coach (lowest fees win on mid-range)",
+    "category": "handbag",
+    "brand": "Coach",
+    "best_platform": "Depop",
+    "verdict": true
+  },
+  {
+    "demo_item_id": "free-people-midi-dress",
+    "narrative_purpose": "Poshmark wins again \u2014 brand-audience alignment",
+    "category": "midi dress",
+    "brand": "Free People",
+    "best_platform": "Poshmark",
+    "verdict": true
+  }
+]

--- a/public/fixtures/jordan-sneakers.json
+++ b/public/fixtures/jordan-sneakers.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "sneakers",
+    "brand": "Jordan",
+    "size": "11",
+    "condition": "Like New",
+    "color": "red",
+    "estimated_retail": 190.0
+  },
+  "recommendations": [
+    {
+      "platform": "eBay",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 51,
+        "balanced": 87,
+        "max_revenue": 138
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 38.38,
+        "balanced": 69.7,
+        "max_revenue": 114.07
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 119.49,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 17,
+      "reasoning": "Sneakerss nets $13 more than Depop and estimated 8 days faster on eBay after 13% fee"
+    },
+    {
+      "platform": "Depop",
+      "rank": 2,
+      "fit_score": 8.2,
+      "price_tiers": {
+        "fast_sale": 35,
+        "balanced": 70,
+        "max_revenue": 159
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 25.51,
+        "balanced": 57.01,
+        "max_revenue": 137.11
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 97.73,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 25,
+      "reasoning": "Depop has lower fees (10%) but estimated net profit is $13 less than eBay (listed-price proxy)"
+    },
+    {
+      "platform": "Poshmark",
+      "rank": 3,
+      "fit_score": 6.3,
+      "price_tiers": {
+        "fast_sale": 44,
+        "balanced": 62,
+        "max_revenue": 88
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 29.21,
+        "balanced": 43.61,
+        "max_revenue": 64.41
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 74.76,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 23,
+      "reasoning": "Poshmark is a viable alternative at $44 net profit in ~23 days (20% fee)"
+    }
+  ],
+  "worth_it": {
+    "verdict": true,
+    "best_net_profit": 69.7,
+    "best_platform": "eBay",
+    "effective_hourly_rate": 119.49,
+    "explanation": "Worth listing \u2014 estimated $38-114 net profit on eBay after fees and shipping"
+  },
+  "demo_item_id": "jordan-sneakers",
+  "demo_narrative_purpose": "Premium sneaker, highest sneaker ROI"
+}

--- a/public/fixtures/levis-denim-jacket.json
+++ b/public/fixtures/levis-denim-jacket.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "denim jacket",
+    "brand": "Levi's",
+    "size": "M",
+    "condition": "Like New",
+    "color": "blue",
+    "estimated_retail": 89.99
+  },
+  "recommendations": [
+    {
+      "platform": "eBay",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 14,
+        "balanced": 34,
+        "max_revenue": 61
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 6.19,
+        "balanced": 23.59,
+        "max_revenue": 47.08
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 40.44,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 29,
+      "reasoning": "Denim Jackets nets $7 more than Depop and estimated 14 days faster on eBay after 13% fee"
+    },
+    {
+      "platform": "Depop",
+      "rank": 2,
+      "fit_score": 7.0,
+      "price_tiers": {
+        "fast_sale": 16,
+        "balanced": 25,
+        "max_revenue": 43
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 8.41,
+        "balanced": 16.51,
+        "max_revenue": 32.71
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 28.3,
+      "sell_probability_30d": 0.7,
+      "estimated_days_to_sale": 43,
+      "reasoning": "Depop has lower fees (10%) but estimated net profit is $7 less than eBay (listed-price proxy)"
+    },
+    {
+      "platform": "Poshmark",
+      "rank": 3,
+      "fit_score": 5.9,
+      "price_tiers": {
+        "fast_sale": 17,
+        "balanced": 25,
+        "max_revenue": 39
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 7.61,
+        "balanced": 14.01,
+        "max_revenue": 25.21
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 24.02,
+      "sell_probability_30d": 0.77,
+      "estimated_days_to_sale": 39,
+      "reasoning": "Poshmark is a viable alternative at $14 net profit in ~39 days (20% fee)"
+    }
+  ],
+  "worth_it": {
+    "verdict": true,
+    "best_net_profit": 23.59,
+    "best_platform": "eBay",
+    "effective_hourly_rate": 40.44,
+    "explanation": "Worth listing \u2014 estimated $6-47 net profit on eBay after fees and shipping"
+  },
+  "demo_item_id": "levis-denim-jacket",
+  "demo_narrative_purpose": "Brand recognition opener \u2014 clear worth-it"
+}

--- a/public/fixtures/levis-leather-jacket.json
+++ b/public/fixtures/levis-leather-jacket.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "leather jacket",
+    "brand": "Levi's",
+    "size": "M",
+    "condition": "Like New",
+    "color": "brown",
+    "estimated_retail": 200.0
+  },
+  "recommendations": [
+    {
+      "platform": "eBay",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 27,
+        "balanced": 59,
+        "max_revenue": 138
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 17.5,
+        "balanced": 45.34,
+        "max_revenue": 114.07
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 77.73,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 25,
+      "reasoning": "Leather Jackets nets $17 more than Poshmark and estimated 8 days faster on eBay after 13% fee"
+    },
+    {
+      "platform": "Poshmark",
+      "rank": 2,
+      "fit_score": 6.3,
+      "price_tiers": {
+        "fast_sale": 25,
+        "balanced": 43,
+        "max_revenue": 74
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 14.01,
+        "balanced": 28.41,
+        "max_revenue": 53.21
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 48.7,
+      "sell_probability_30d": 0.91,
+      "estimated_days_to_sale": 33,
+      "reasoning": "Poshmark is a viable alternative at $28 net profit in ~33 days (20% fee)"
+    },
+    {
+      "platform": "Depop",
+      "rank": 3,
+      "fit_score": 6.0,
+      "price_tiers": {
+        "fast_sale": 21,
+        "balanced": 37,
+        "max_revenue": 73
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 12.91,
+        "balanced": 27.31,
+        "max_revenue": 59.71
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 46.82,
+      "sell_probability_30d": 0.83,
+      "estimated_days_to_sale": 36,
+      "reasoning": "Depop has lower fees (10%) but estimated net profit is $18 less than eBay (limited training data \u2014 listed-price proxy)"
+    }
+  ],
+  "worth_it": {
+    "verdict": true,
+    "best_net_profit": 45.34,
+    "best_platform": "eBay",
+    "effective_hourly_rate": 77.73,
+    "explanation": "Worth listing \u2014 estimated $18-114 net profit on eBay after fees and shipping"
+  },
+  "demo_item_id": "levis-leather-jacket",
+  "demo_narrative_purpose": "High-value 2-way item, strong premium signal"
+}

--- a/public/fixtures/louis-vuitton-handbag.json
+++ b/public/fixtures/louis-vuitton-handbag.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "handbag",
+    "brand": "Louis Vuitton",
+    "size": "OS",
+    "condition": "Like New",
+    "color": "brown",
+    "estimated_retail": 2000.0
+  },
+  "recommendations": [
+    {
+      "platform": "eBay",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 147,
+        "balanced": 342,
+        "max_revenue": 789
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 121.9,
+        "balanced": 291.55,
+        "max_revenue": 680.44
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 499.8,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 16,
+      "reasoning": "Handbags nets $41 more than Poshmark and estimated 6 days faster on eBay after 13% fee"
+    },
+    {
+      "platform": "Poshmark",
+      "rank": 2,
+      "fit_score": 8.6,
+      "price_tiers": {
+        "fast_sale": 135,
+        "balanced": 321,
+        "max_revenue": 761
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 102.01,
+        "balanced": 250.81,
+        "max_revenue": 602.81
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 429.96,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 22,
+      "reasoning": "Poshmark is a viable alternative at $251 net profit in ~22 days (20% fee)"
+    },
+    {
+      "platform": "Depop",
+      "rank": 3,
+      "fit_score": 7.3,
+      "price_tiers": {
+        "fast_sale": 191,
+        "balanced": 242,
+        "max_revenue": 520
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 165.91,
+        "balanced": 211.81,
+        "max_revenue": 462.01
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 363.1,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 24,
+      "reasoning": "Depop has lower fees (10%) but estimated net profit is $80 less than eBay (listed-price proxy)"
+    }
+  ],
+  "worth_it": {
+    "verdict": true,
+    "best_net_profit": 291.55,
+    "best_platform": "eBay",
+    "effective_hourly_rate": 499.8,
+    "explanation": "Worth listing \u2014 estimated $122-680 net profit on eBay after fees and shipping"
+  },
+  "demo_item_id": "louis-vuitton-handbag",
+  "demo_narrative_purpose": "Luxury showcase \u2014 dramatic $/hr (note: luxury tier has high model uncertainty, MAE $339)"
+}

--- a/public/fixtures/nike-sneakers.json
+++ b/public/fixtures/nike-sneakers.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "sneakers",
+    "brand": "Nike",
+    "size": "10",
+    "condition": "New",
+    "color": "white",
+    "estimated_retail": 120.0
+  },
+  "recommendations": [
+    {
+      "platform": "eBay",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 40,
+        "balanced": 68,
+        "max_revenue": 108
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 28.81,
+        "balanced": 53.17,
+        "max_revenue": 87.97
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 91.15,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 17,
+      "reasoning": "Sneakerss nets $15 more than Depop and estimated 8 days faster on eBay after 13% fee"
+    },
+    {
+      "platform": "Depop",
+      "rank": 2,
+      "fit_score": 7.2,
+      "price_tiers": {
+        "fast_sale": 24,
+        "balanced": 49,
+        "max_revenue": 111
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 15.61,
+        "balanced": 38.11,
+        "max_revenue": 93.91
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 65.33,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 25,
+      "reasoning": "Depop has lower fees (10%) but estimated net profit is $15 less than eBay (listed-price proxy)"
+    },
+    {
+      "platform": "Poshmark",
+      "rank": 3,
+      "fit_score": 6.4,
+      "price_tiers": {
+        "fast_sale": 36,
+        "balanced": 50,
+        "max_revenue": 72
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 22.81,
+        "balanced": 34.01,
+        "max_revenue": 51.61
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 58.3,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 23,
+      "reasoning": "Poshmark is a viable alternative at $34 net profit in ~23 days (20% fee)"
+    }
+  ],
+  "worth_it": {
+    "verdict": true,
+    "best_net_profit": 53.17,
+    "best_platform": "eBay",
+    "effective_hourly_rate": 91.15,
+    "explanation": "Worth listing \u2014 estimated $29-88 net profit on eBay after fees and shipping"
+  },
+  "demo_item_id": "nike-sneakers",
+  "demo_narrative_purpose": "Mass-market brand, high confidence routing"
+}

--- a/public/fixtures/old-navy-denim-jacket.json
+++ b/public/fixtures/old-navy-denim-jacket.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "denim jacket",
+    "brand": "Old Navy",
+    "size": "M",
+    "condition": "Good",
+    "color": "blue",
+    "estimated_retail": 35.0
+  },
+  "recommendations": [
+    {
+      "platform": "Depop",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 9,
+        "balanced": 15,
+        "max_revenue": 25
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 2.11,
+        "balanced": 7.51,
+        "max_revenue": 16.51
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 12.87,
+      "sell_probability_30d": 0.7,
+      "estimated_days_to_sale": 43,
+      "reasoning": "Denim Jackets nets $2 more than Poshmark on Depop after 10% fee (listed-price proxy)"
+    },
+    {
+      "platform": "Poshmark",
+      "rank": 2,
+      "fit_score": 8.0,
+      "price_tiers": {
+        "fast_sale": 11,
+        "balanced": 15,
+        "max_revenue": 24
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 2.81,
+        "balanced": 6.01,
+        "max_revenue": 13.21
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 10.3,
+      "sell_probability_30d": 0.77,
+      "estimated_days_to_sale": 39,
+      "reasoning": "Poshmark offers faster sell-through (~39 days, 4 days quicker) but 20% fee leaves $2 less net profit"
+    },
+    {
+      "platform": "eBay",
+      "rank": 3,
+      "fit_score": 7.1,
+      "price_tiers": {
+        "fast_sale": 6,
+        "balanced": 13,
+        "max_revenue": 24
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": -0.77,
+        "balanced": 5.32,
+        "max_revenue": 14.89
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 9.12,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 29,
+      "reasoning": "eBay offers faster sell-through (~29 days, 14 days quicker) but 13% fee leaves $2 less net profit"
+    }
+  ],
+  "worth_it": {
+    "verdict": false,
+    "best_net_profit": 7.51,
+    "best_platform": "Depop",
+    "effective_hourly_rate": 12.87,
+    "explanation": "Not worth listing \u2014 estimated $8 net profit on Depop yields only $13/hr effective rate"
+  },
+  "demo_item_id": "old-navy-denim-jacket",
+  "demo_narrative_purpose": "THE 'don't sell' punchline \u2014 $13/hr, not worth your time"
+}

--- a/public/fixtures/unknown-blazer.json
+++ b/public/fixtures/unknown-blazer.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "blazer",
+    "brand": "Unknown",
+    "size": "L",
+    "condition": "Good",
+    "color": "gray",
+    "estimated_retail": 40.0
+  },
+  "recommendations": [
+    {
+      "platform": "Poshmark",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 12,
+        "balanced": 22,
+        "max_revenue": 35
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 3.61,
+        "balanced": 11.61,
+        "max_revenue": 22.01
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 19.9,
+      "sell_probability_30d": 0.86,
+      "estimated_days_to_sale": 35,
+      "reasoning": "Blazers nets $1 more than Depop and estimated 3 days faster on Poshmark after 20% fee"
+    },
+    {
+      "platform": "Depop",
+      "rank": 2,
+      "fit_score": 8.8,
+      "price_tiers": {
+        "fast_sale": 10,
+        "balanced": 18,
+        "max_revenue": 36
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 3.01,
+        "balanced": 10.21,
+        "max_revenue": 26.41
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 17.5,
+      "sell_probability_30d": 0.79,
+      "estimated_days_to_sale": 38,
+      "reasoning": "Depop has lower fees (10%) but estimated net profit is $1 less than Poshmark (limited training data \u2014 listed-price proxy)"
+    },
+    {
+      "platform": "eBay",
+      "rank": 3,
+      "fit_score": 7.6,
+      "price_tiers": {
+        "fast_sale": 9,
+        "balanced": 17,
+        "max_revenue": 30
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 1.84,
+        "balanced": 8.8,
+        "max_revenue": 20.11
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 15.09,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 26,
+      "reasoning": "eBay offers faster sell-through (~26 days, 9 days quicker) but 13% fee leaves $3 less net profit"
+    }
+  ],
+  "worth_it": {
+    "verdict": "marginal",
+    "best_net_profit": 11.61,
+    "best_platform": "Poshmark",
+    "effective_hourly_rate": 19.9,
+    "explanation": "Marginal \u2014 estimated $12 net profit on Poshmark, but effective hourly rate ($20/hr) is below $25"
+  },
+  "demo_item_id": "unknown-blazer",
+  "demo_narrative_purpose": "No brand signal, low confidence \u2014 marginal verdict"
+}

--- a/public/fixtures/unknown-denim-jacket.json
+++ b/public/fixtures/unknown-denim-jacket.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "denim jacket",
+    "brand": "Unknown",
+    "size": "L",
+    "condition": "Good",
+    "color": "black",
+    "estimated_retail": 30.0
+  },
+  "recommendations": [
+    {
+      "platform": "Depop",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 12,
+        "balanced": 19,
+        "max_revenue": 32
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 4.81,
+        "balanced": 11.11,
+        "max_revenue": 22.81
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 19.05,
+      "sell_probability_30d": 0.7,
+      "estimated_days_to_sale": 43,
+      "reasoning": "Denim Jackets nets $1 more than Poshmark on Depop after 10% fee (listed-price proxy)"
+    },
+    {
+      "platform": "Poshmark",
+      "rank": 2,
+      "fit_score": 9.0,
+      "price_tiers": {
+        "fast_sale": 14,
+        "balanced": 20,
+        "max_revenue": 31
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 5.21,
+        "balanced": 10.01,
+        "max_revenue": 18.81
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 17.16,
+      "sell_probability_30d": 0.77,
+      "estimated_days_to_sale": 39,
+      "reasoning": "Poshmark offers faster sell-through (~39 days, 4 days quicker) but 20% fee leaves $1 less net profit"
+    },
+    {
+      "platform": "eBay",
+      "rank": 3,
+      "fit_score": 8.7,
+      "price_tiers": {
+        "fast_sale": 8,
+        "balanced": 18,
+        "max_revenue": 32
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 0.97,
+        "balanced": 9.67,
+        "max_revenue": 21.85
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 16.58,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 29,
+      "reasoning": "eBay offers faster sell-through (~29 days, 14 days quicker) but 13% fee leaves $1 less net profit"
+    }
+  ],
+  "worth_it": {
+    "verdict": "marginal",
+    "best_net_profit": 11.11,
+    "best_platform": "Depop",
+    "effective_hourly_rate": 19.05,
+    "explanation": "Marginal \u2014 estimated $11 net profit on Depop, but effective hourly rate ($19/hr) is below $25"
+  },
+  "demo_item_id": "unknown-denim-jacket",
+  "demo_narrative_purpose": "Marginal unknown brand \u2014 borderline at $19/hr, reinforces 'think twice'"
+}

--- a/public/fixtures/unknown-midi-dress.json
+++ b/public/fixtures/unknown-midi-dress.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "midi dress",
+    "brand": "Unknown",
+    "size": "L",
+    "condition": "Good",
+    "color": "gray",
+    "estimated_retail": 15.0
+  },
+  "recommendations": [
+    {
+      "platform": "Poshmark",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 16,
+        "balanced": 23,
+        "max_revenue": 35
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 6.81,
+        "balanced": 12.41,
+        "max_revenue": 22.01
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 21.27,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 23,
+      "reasoning": "Midi Dresss nets $1 more than Depop on Poshmark after 20% fee"
+    },
+    {
+      "platform": "Depop",
+      "rank": 2,
+      "fit_score": 9.0,
+      "price_tiers": {
+        "fast_sale": 10,
+        "balanced": 19,
+        "max_revenue": 34
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 3.01,
+        "balanced": 11.11,
+        "max_revenue": 24.61
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 19.05,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 25,
+      "reasoning": "Depop has lower fees (10%) but estimated net profit is $1 less than Poshmark (listed-price proxy)"
+    },
+    {
+      "platform": "eBay",
+      "rank": 3,
+      "fit_score": 5.0,
+      "price_tiers": {
+        "fast_sale": 7,
+        "balanced": 14,
+        "max_revenue": 27
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 0.1,
+        "balanced": 6.19,
+        "max_revenue": 17.5
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 10.61,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 17,
+      "reasoning": "eBay offers faster sell-through (~17 days, 6 days quicker) but 13% fee leaves $6 less net profit"
+    }
+  ],
+  "worth_it": {
+    "verdict": "marginal",
+    "best_net_profit": 12.41,
+    "best_platform": "Poshmark",
+    "effective_hourly_rate": 21.27,
+    "explanation": "Marginal \u2014 estimated $12 net profit on Poshmark, but effective hourly rate ($21/hr) is below $25"
+  },
+  "demo_item_id": "unknown-midi-dress",
+  "demo_narrative_purpose": "Cheapest item in demo \u2014 barely above threshold"
+}

--- a/public/fixtures/zara-denim-jacket.json
+++ b/public/fixtures/zara-denim-jacket.json
@@ -1,0 +1,87 @@
+{
+  "item": {
+    "category": "denim jacket",
+    "brand": "Zara",
+    "size": "S",
+    "condition": "Good",
+    "color": "light wash",
+    "estimated_retail": 49.99
+  },
+  "recommendations": [
+    {
+      "platform": "Depop",
+      "rank": 1,
+      "fit_score": 10.0,
+      "price_tiers": {
+        "fast_sale": 13,
+        "balanced": 20,
+        "max_revenue": 34
+      },
+      "platform_fee_pct": 0.1,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 5.71,
+        "balanced": 12.01,
+        "max_revenue": 24.61
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 20.59,
+      "sell_probability_30d": 0.7,
+      "estimated_days_to_sale": 43,
+      "reasoning": "Best overall value for denim jackets on Depop \u2014 $12 net profit in ~43 days (listed-price proxy)"
+    },
+    {
+      "platform": "Poshmark",
+      "rank": 2,
+      "fit_score": 9.7,
+      "price_tiers": {
+        "fast_sale": 15,
+        "balanced": 22,
+        "max_revenue": 34
+      },
+      "platform_fee_pct": 0.2,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 6.01,
+        "balanced": 11.61,
+        "max_revenue": 21.21
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 19.9,
+      "sell_probability_30d": 0.77,
+      "estimated_days_to_sale": 39,
+      "reasoning": "Poshmark offers faster sell-through (~39 days, 4 days quicker) but 20% fee leaves $0 less net profit"
+    },
+    {
+      "platform": "eBay",
+      "rank": 3,
+      "fit_score": 8.1,
+      "price_tiers": {
+        "fast_sale": 8,
+        "balanced": 18,
+        "max_revenue": 32
+      },
+      "platform_fee_pct": 0.13,
+      "estimated_shipping": 5.99,
+      "net_profit": {
+        "fast_sale": 0.97,
+        "balanced": 9.67,
+        "max_revenue": 21.85
+      },
+      "estimated_time_minutes": 35,
+      "effective_hourly_rate": 16.58,
+      "sell_probability_30d": 1.0,
+      "estimated_days_to_sale": 29,
+      "reasoning": "eBay offers faster sell-through (~29 days, 14 days quicker) but 13% fee leaves $2 less net profit"
+    }
+  ],
+  "worth_it": {
+    "verdict": "marginal",
+    "best_net_profit": 12.01,
+    "best_platform": "Depop",
+    "effective_hourly_rate": 20.59,
+    "explanation": "Marginal \u2014 estimated $12 net profit on Depop, but effective hourly rate ($21/hr) is below $25"
+  },
+  "demo_item_id": "zara-denim-jacket",
+  "demo_narrative_purpose": "Known brand but low margin category \u2014 marginal zone"
+}

--- a/src/data/fixtureLoader.ts
+++ b/src/data/fixtureLoader.ts
@@ -1,0 +1,38 @@
+import { AnalysisResult, FixtureMeta } from "@/types/api";
+
+const DEMO_IMAGES: Record<string, string> = {
+  "levis-denim-jacket": "https://images.unsplash.com/photo-1576995853123-5a10305d93c0?w=400",
+  "nike-sneakers": "https://images.unsplash.com/photo-1542291026-7eec264c27ff?w=400",
+  "jordan-sneakers": "https://images.unsplash.com/photo-1552346154-21d32810aba3?w=400",
+  "louis-vuitton-handbag": "https://images.unsplash.com/photo-1584917865442-de89df76afd3?w=400",
+  "coach-crossbody-bag": "https://images.unsplash.com/photo-1548036328-c9fa89d128fa?w=400",
+  "anthropologie-midi-dress": "https://images.unsplash.com/photo-1595777457583-95e059d581b8?w=400",
+  "harley-davidson-vintage-t-shirt": "https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?w=400",
+  "levis-leather-jacket": "https://images.unsplash.com/photo-1551028719-00167b16eac5?w=400",
+  "handm-midi-dress": "https://images.unsplash.com/photo-1572804013309-59a88b7e92f1?w=400",
+  "unknown-blazer": "https://images.unsplash.com/photo-1594938298603-c8148c4dae35?w=400",
+  "unknown-midi-dress": "https://images.unsplash.com/photo-1585487000160-6ebcfceb0d03?w=400",
+  "zara-denim-jacket": "https://images.unsplash.com/photo-1591047139829-d91aecb6caea?w=400",
+  "old-navy-denim-jacket": "https://images.unsplash.com/photo-1544022613-e87ca75a784a?w=400",
+  "unknown-denim-jacket": "https://images.unsplash.com/photo-1516257984-b1b4d707412e?w=400",
+  "coach-handbag": "https://images.unsplash.com/photo-1590874103328-eac38a683ce7?w=400",
+  "free-people-midi-dress": "https://images.unsplash.com/photo-1612336307429-8a898d10e223?w=400",
+};
+
+export async function loadFixtureIndex(): Promise<FixtureMeta[]> {
+  const res = await fetch("/fixtures/index.json");
+  if (!res.ok) throw new Error(`Failed to load fixture index: ${res.status}`);
+  return res.json();
+}
+
+export async function loadFixture(demoItemId: string): Promise<AnalysisResult> {
+  const res = await fetch(`/fixtures/${demoItemId}.json`);
+  if (!res.ok) throw new Error(`Failed to load fixture ${demoItemId}: ${res.status}`);
+  const result = (await res.json()) as AnalysisResult;
+
+  if (!result.item.image_url && DEMO_IMAGES[demoItemId]) {
+    result.item.image_url = DEMO_IMAGES[demoItemId];
+  }
+
+  return result;
+}

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,3 +1,6 @@
+// DEPRECATED: This file is no longer imported. Fixture data now comes from
+// public/fixtures/*.json via src/data/fixtureLoader.ts. Kept as a reference
+// for the data shape. Safe to delete after demo day if no regressions.
 import { AnalysisResult } from "@/types/api";
 
 export const mockDenimJacket: AnalysisResult = {

--- a/src/pages/Analyze.tsx
+++ b/src/pages/Analyze.tsx
@@ -10,46 +10,53 @@ import PriceTiersComponent from "@/components/results/PriceTiers";
 import SellEstimate from "@/components/results/SellEstimate";
 import WhyThisPlatform from "@/components/results/WhyThisPlatform";
 import Footer from "@/components/layout/Footer";
-import { allMockItems } from "@/data/mockData";
+import { loadFixture } from "@/data/fixtureLoader";
 import { AnalysisResult, AIDetectedAttributes } from "@/types/api";
 
-const exampleLabels = ["Denim Jacket", "Sneakers", "Handbag", "T-Shirt"];
+const exampleLabels = ["Levi's Denim Jacket", "Coach Handbag", "H&M Midi Dress", "Old Navy Denim Jacket"];
+const exampleDemoIds = ["levis-denim-jacket", "coach-handbag", "handm-midi-dress", "old-navy-denim-jacket"];
 
 type Step = "upload" | "confirm" | "loading" | "results";
 
 const Analyze = () => {
   const [step, setStep] = useState<Step>("upload");
-  const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const [result, setResult] = useState<AnalysisResult | null>(null);
   const [detected, setDetected] = useState<AIDetectedAttributes | null>(null);
   const resultsRef = useRef<HTMLDivElement>(null);
 
-  const handleExampleSelect = (index: number) => {
-    setSelectedIndex(index);
-    const item = allMockItems[index].item;
-    setDetected({
-      category: item.category,
-      color: item.color,
-      condition: item.condition,
-      image_url: item.image_url,
-    });
-    setStep("confirm");
+  const handleExampleSelect = async (index: number) => {
+    try {
+      const fixture = await loadFixture(exampleDemoIds[index]);
+      setResult(fixture);
+      setDetected({
+        category: fixture.item.category,
+        color: fixture.item.color,
+        condition: fixture.item.condition,
+        image_url: fixture.item.image_url,
+      });
+      setStep("confirm");
+    } catch (err) {
+      console.error("Failed to load fixture:", err);
+    }
   };
 
-  const handleFileSelected = (_file: File) => {
-    setSelectedIndex(0);
-    const item = allMockItems[0].item;
-    setDetected({
-      category: item.category,
-      color: item.color,
-      condition: item.condition,
-      image_url: item.image_url,
-    });
-    setStep("confirm");
+  const handleFileSelected = async (_file: File) => {
+    try {
+      const fixture = await loadFixture(exampleDemoIds[0]);
+      setResult(fixture);
+      setDetected({
+        category: fixture.item.category,
+        color: fixture.item.color,
+        condition: fixture.item.condition,
+        image_url: fixture.item.image_url,
+      });
+      setStep("confirm");
+    } catch (err) {
+      console.error("Failed to load fixture:", err);
+    }
   };
 
   const handleConfirm = () => {
-    setResult(allMockItems[selectedIndex]);
     setStep("loading");
   };
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -47,6 +47,8 @@ export interface AnalysisResult {
   item: ItemData;
   recommendations: PlatformRecommendation[];
   worth_it: WorthItVerdict;
+  demo_item_id?: string;
+  demo_narrative_purpose?: string;
 }
 
 export interface AIDetectedAttributes {
@@ -55,4 +57,13 @@ export interface AIDetectedAttributes {
   condition: string;
   style?: string;
   image_url?: string;
+}
+
+export interface FixtureMeta {
+  demo_item_id: string;
+  narrative_purpose: string;
+  category: string;
+  brand: string;
+  best_platform: string;
+  verdict: boolean | "marginal";
 }


### PR DESCRIPTION
Replaces mock data with 16 pre-computed recommendations from the backend team. Schema matches locked API contract. Demo order follows pitch script: Levi's (opener) → Coach handbag (routing surprise) → H&M (marginal) → Old Navy (don't sell punchline).

## Summary
- Copied all 16 fixtures + `index.json` from `listiq-backend/demo/fixtures/` into `public/fixtures/`
- Added `src/data/fixtureLoader.ts` with `loadFixture` / `loadFixtureIndex` and an image URL map keyed by `demo_item_id`
- Updated `src/pages/Analyze.tsx` to load real fixture JSON asynchronously — no result-component changes
- Wired the 4 curated demo items in pitch-script order (Levi's, Coach Handbag, H&M, Old Navy)
- Extended `src/types/api.ts` with `FixtureMeta` and optional `demo_item_id` / `demo_narrative_purpose` on `AnalysisResult`
- Deprecated `src/data/mockData.ts` (kept as reference per instructions)

## Test plan
- [ ] `npm run dev`, visit `/analyze`
- [ ] Click **Levi's Denim Jacket** → verdict green, ~\$40/hr, eBay rank 1
- [ ] Click **Coach Handbag** → Depop rank 1 (routing surprise)
- [ ] Click **H&M Midi Dress** → marginal verdict around \$27/hr
- [ ] Click **Old Navy Denim Jacket** → RED "Not Worth Listing", \$13/hr, eBay fast_sale net profit \$-0.77 renders without breaking layout
- [ ] Confirm no console errors on any of the 4
- [ ] `npm run build` passes